### PR TITLE
Evaluate Regular Expression button checks sample file name, shows results in window

### DIFF
--- a/Phindr3D-Python/src/Data/DataFunctions.py
+++ b/Phindr3D-Python/src/Data/DataFunctions.py
@@ -27,67 +27,24 @@ class DataFunctions:
     No constructor. All parameters and methods are static.
     """
 
-
-
-    # replace this with a single comparison for one file to make a dictionary with the
-    # Well, Stack, Channel, etc. to display in a window after clicking "Evaluate Regular Expression"
-
     @staticmethod
     def parseAndCompareRegex(sampleFile, regex):
         """Given a sample file name string and a regex string, parse the file name
             and find the fields specified in the regular expression. If no fields
-            can be found, return None. Otherwise, return a dictionary with the
-            field names and their values."""
-
+            can be found, return empty dictionary. Otherwise, return a dictionary with the
+            field names and their values. On re.error return empty dictionary. """
+        outdict = {}
         # Check that both sampleFile and regex are strings
-
-        #m = re.fullmatch(regex, sampleFile)
-        #if m != None:
-        #    pass
-            # ...
-
-        print("Finished parseAndCompareRegex")
-
+        try:
+            m = re.fullmatch(regex, sampleFile)
+            if m is None:
+                outdict = {}
+            else:
+                outdict = m.groupdict()
+        except re.error:
+            outdict = {}
+        return outdict
     # end parseAndCompareRegex
-
-
-    @staticmethod
-    def parseAndSearchRegex(folderPath, regex, numResults=-1, useAbsPath=True):
-        """This function returns an empty list if the folderPath cannot be found,
-            or if the regular expression returns no results.
-            It returns a list of file name strings on success,
-            where the number of list elements will be all the file names
-            in the directory if numResults is less than 0.
-            If numResults is less than the number of files in the directory,
-            numResults elements are returned. If numResults is greater, then
-            the list will contain all the file names in the directory."""
-
-        # Error handling
-        # directoryExists(folderPath)
-        #
-
-        regexResults = []
-        f = os.listdir(folderPath)
-        #read images in folder
-        for i, file in enumerate(f):
-            m = re.fullmatch(regex, file)
-            if m != None:
-                d = m.groupdict()
-                d['_file'] = os.path.abspath(f'{folderPath}\\{file}') if useAbsPath else file
-                regexResults.append(d)
-
-        if len(regexResults) == 0 or numResults == 0:
-            return []
-        elif numResults < 0:
-            return regexResults
-        elif len(regexResults) > numResults:
-            return regexResults[:numResults]
-        else:
-            return regexResults
-    # end parseAndSearchRegex
-
-
-
 
     @staticmethod
     def directoryExists(theDir):
@@ -190,8 +147,9 @@ class DataFunctions:
 
 # end DataFunctions
 
-
-
+# error classes
+class MissingChannelStackError(Exception):
+    pass
 
 
 def test_directoryExists():
@@ -225,27 +183,26 @@ def test_directoryExists():
 # end test_directoryExists
 
 
-
-
 def test_parseAndCompareRegex():
     """A set of tests of the static method parseAndCompareRegex"""
     success = "Success in test_parseAndCompareRegex test "
     failure = "Failure in test_parseAndCompareRegex test "
     # Test 1
     tnum = 1
+    t1expected = {'Well': 'r03c19', 'Field': '01', 'Stack': '15', 'Channel': '2'}
+    t1file = "r03c19f01p15-ch2sk1fk1fl1.tiff"
+    t1regex = "(?<Well>\w+)f(?<Field>\d+)p(?<Stack>\d+)-ch(?<Channel>\d).*.tif(f)?"
+    t1regex = DataFunctions.regexPatternCompatibility(t1regex)
+    t1out = DataFunctions.parseAndCompareRegex(t1file, t1regex)
+    print(success + str(tnum) if t1out == t1expected else failure + str(tnum))
 
 # end test_parseAndCompareRegex
 
-# error classes
-
-class MissingChannelStackError(Exception):
-    pass
 
 if __name__ == '__main__':
     """Tests of the static methods that can be run directly."""
-    #test_directoryExists()
 
-    # test_parseAndCompareRegex()
-
+    test_directoryExists()
+    test_parseAndCompareRegex()
 
 # end if main

--- a/Phindr3D-Python/src/Data/DataFunctions.py
+++ b/Phindr3D-Python/src/Data/DataFunctions.py
@@ -41,12 +41,12 @@ class DataFunctions:
 
         # Check that both sampleFile and regex are strings
 
-        m = re.fullmatch(regex, sampleFile)
-        if m != None:
-            pass
+        #m = re.fullmatch(regex, sampleFile)
+        #if m != None:
+        #    pass
             # ...
 
-
+        print("Finished parseAndCompareRegex")
 
     # end parseAndCompareRegex
 

--- a/Phindr3D-Python/src/Data/DataFunctions.py
+++ b/Phindr3D-Python/src/Data/DataFunctions.py
@@ -101,6 +101,28 @@ class DataFunctions:
             return os.path.exists(theDir)
     # end directoryExists
 
+    @staticmethod
+    def regexPatternCompatibility(regex):
+        """Provides compatibility between MATLAB regular expressions and Python.
+            Replaces '?<' patterns with '?P<' to make compatible with re.fullmatch function.
+            It first checks if '?<' corresponds to a '?<=' or '?<!' pattern first before replacing
+            part of Python specific regular expression syntax."""
+        # set the default value if no modifications are necessary
+        outstring = ""
+        strlist = regex.split("?<")
+        if len(strlist) <= 1:
+            return regex
+        else:
+            for i in range(len(strlist)-1):
+                outstring = outstring+strlist[i]
+                try:
+                    theSep = "?<" if (strlist[i+1][0] == '=' or strlist[i+1][0] == '!') else "?P<"
+                except IndexError:
+                    theSep = "?<"
+                outstring = outstring + theSep
+            outstring = outstring+strlist[len(strlist)-1]
+        return outstring
+    # end regexPatternCompatibility
 
     @staticmethod
     def createMetadata(folder_path, regex, mdatafilename='metadata_python.txt'):
@@ -223,8 +245,7 @@ if __name__ == '__main__':
     """Tests of the static methods that can be run directly."""
     #test_directoryExists()
 
-    test_parseAndCompareRegex()
-
+    # test_parseAndCompareRegex()
 
 
 # end if main

--- a/Phindr3D-Python/src/Data/Metadata.py
+++ b/Phindr3D-Python/src/Data/Metadata.py
@@ -249,13 +249,14 @@ class Metadata:
     # rescale intensities
     # threshold images
 
-    # class attributes
-    # output metadata file name
+
+
+
+
+
 
 
 # end class Metadata
-
-
 
 if __name__ == '__main__':
     """Tests of the Metadata class that can be run directly."""
@@ -263,19 +264,22 @@ if __name__ == '__main__':
     # Running will prompt user for a text file, image id, stack id, and channel number
     # Since this is only for testing purposes, assume inputted values are all correct types
 
-    metadatafile = input("Metadata file: ")
-    imageid = float(input("Image ID: "))
-    stackid = int(input("Stack ID: "))
-    channelnumber = int(input("Channel Number: "))
+    # metadatafile = r"R:\\Phindr3D-Dataset\\neurondata\\Phindr3D_neuron-sample-data\\metaout_metadatafile.txt"
+    metadatafile = r"R:\\Phindr3D-Dataset\\Phindr3D_TreatmentID_sample_data\\metadata_python.txt"
+
+    # metadatafile = input("Metadata file: ")
+    # imageid = float(input("Image ID: "))
+    # stackid = int(input("Stack ID: "))
+    # channelnumber = int(input("Channel Number: "))
     test = Metadata()
     if test.loadMetadataFile(metadatafile):
-        print('Result:', test.images[imageid].layers[stackid].channels[channelnumber].channelpath)
+        # print('Result:', test.images[imageid].layers[stackid].channels[channelnumber].channelpath)
         # using pandas, search through dataframe to find the correct element
-        metadata = pandas.read_table(metadatafile, usecols=lambda c: not c.startswith('Unnamed:'), delimiter='\t')
-        numrows = metadata.shape[0]
-        for i in range(numrows):
-            if (metadata.at[i, 'Stack'] == stackid) and (metadata.at[i, 'ImageID'] == imageid):
-                print('Expect:', metadata.at[i, f'Channel_{channelnumber}'])
+        # metadata = pandas.read_table(metadatafile, usecols=lambda c: not c.startswith('Unnamed:'), delimiter='\t')
+        # numrows = metadata.shape[0]
+        # for i in range(numrows):
+        #    if (metadata.at[i, 'Stack'] == stackid) and (metadata.at[i, 'ImageID'] == imageid):
+        #        print('Expect:', metadata.at[i, f'Channel_{channelnumber}'])
         print("So, did it load? " + "Yes!" if test.metadataLoadSuccess else "No.")
         print("===")
         print("Running computeImageParameters: " + "Successful" if test.computeImageParameters() else "Unsuccessful")

--- a/Phindr3D-Python/src/GUI/external_windows.py
+++ b/Phindr3D-Python/src/GUI/external_windows.py
@@ -176,7 +176,7 @@ class extractWindow(QDialog):
         largetext = QFont("Arial", 12, 1)
         self.setWindowTitle("Extract Metadata")
         directory = "Image Root Directory"
-        samplefilename = "Sample File Name"
+        self.samplefilename = "Sample File Name"
         layout = QGridLayout()
         imagerootbox = QTextEdit()
         imagerootbox.setReadOnly(True)
@@ -191,7 +191,7 @@ class extractWindow(QDialog):
 
         samplefilebox = QTextEdit()
         samplefilebox.setReadOnly(True)
-        samplefilebox.setPlaceholderText(samplefilename)
+        samplefilebox.setPlaceholderText(self.samplefilename)
         samplefilebox.setAlignment(Qt.AlignHCenter | Qt.AlignTop)
         samplefilebox.setFont(largetext)
         samplefilebox.setFixedSize(450, 30)
@@ -235,7 +235,6 @@ class extractWindow(QDialog):
             imagedir = imagerootbox.toPlainText()
             regex = expressionbox.text()
             outputname = outputfilebox.text()
-            datas = DataFunctions()
             # replace '?<' patterns with '?P<' to make compatible with re.fullmatch function
             # first checks if '?<' corresponds to a '?<=' or '?<!' pattern first before replacing
             # part of Python specific regular expression syntax
@@ -252,9 +251,9 @@ class extractWindow(QDialog):
                 alert = QMessageBox()
                 try:
                     if outputname != "":
-                        created = datas.createMetadata(imagedir, regex, outputname)
+                        created = DataFunctions.createMetadata(imagedir, regex, outputname)
                     else:
-                        created = datas.createMetadata(imagedir, regex)
+                        created = DataFunctions.createMetadata(imagedir, regex)
                     if created:
                         alert.setText("Metadata creation success.")
                         alert.setIcon(QMessageBox.Information)
@@ -275,15 +274,53 @@ class extractWindow(QDialog):
                 alert.setIcon(QMessageBox.Critical)
                 alert.show()
                 alert.exec()
+
         def evalRegex():
             regex = expressionbox.text()
             samplefile = samplefilebox.toPlainText()
-            if regex == "" or samplefile == samplefilename:
-                return
-            datas = DataFunctions()
-            regexdict = datas.parseAndCompareRegex(samplefile, regex)
-            if regexdict != None:
-                print(regexdict)
+
+
+            # if regex == "" or samplefile == "":
+                # show error window for regex blank, different error for samplefile blank
+            #    print("regex field is blank or samplefile thing: "+samplefile+"")
+            #    return
+            #DataFunctions.parseAndCompareRegex(samplefile, regex)
+            #if regexdict != None:
+            #    print(regexdict)
+
+            # testdict = {"one": 1, "two": 2, "three": 3}
+            # testdict.keys()
+
+            reout = {}
+
+            winex = QDialog()
+            winex.setWindowTitle("Evaluate Regular Expression")
+            winlayout = QGridLayout()
+            labelText = "Regular Expression Match"
+            # List of regex keys and values
+            relist = QListWidget()
+            if len(reout) == 0:
+                relist.addItem("No results")
+            else:
+                for rekey in reout.keys():
+                    nextline = str(rekey)+" ::: "+str(reout[rekey])
+                    relist.addItem(nextline)
+            # Ok button closes the window
+            reok = QPushButton("Ok")
+            # button behaviour
+            def okPressed():
+                winex.close()
+            reok.clicked.connect(okPressed)
+
+            # add the widgets to the layout
+            winlayout.addWidget(QLabel(labelText))
+            winlayout.addWidget(relist)
+            winlayout.addWidget(reok)
+            # add the layout and show the window
+            winex.setLayout(winlayout)
+            winex.show()
+            winex.exec()
+        #end evalRegex
 
         cancel.clicked.connect(self.close)
         selectimage.clicked.connect(selectImageDir)
@@ -301,6 +338,8 @@ class extractWindow(QDialog):
         layout.setSpacing(10)
         self.setLayout(layout)
         self.setFixedSize(self.minimumSizeHint())
+    # end __init__
+# end extractWindow
 
 class resultsWindow(QDialog):
     def __init__(self):
@@ -452,7 +491,7 @@ class resultsWindow(QDialog):
         alert.setText(errormessage)
         alert.setIcon(icon)
         return alert
-
+# end resultsWindow
 
 class paramWindow(QDialog):
     def __init__(self):
@@ -523,7 +562,7 @@ class paramWindow(QDialog):
         trainingimages = QLineEdit()
         trainingimages.setFixedWidth(30)
         usebackground = QCheckBox("Use Background Voxels for comparing") # text is cutoff, don't know actual line?
-        normalise = QCheckBox("Normalise Intesity\n Per Condition")
+        normalise = QCheckBox("Normalise Intensity\n Per Condition")
         trainbycondition = QCheckBox("Train by condition")
         leftdropdown = QComboBox()
         leftdropdown.setEnabled(False)
@@ -726,3 +765,4 @@ class external_windows():
 
     def buildColorchannelWindow(self):
         return colorchannelWindow()
+

--- a/Phindr3D-Python/src/GUI/external_windows.py
+++ b/Phindr3D-Python/src/GUI/external_windows.py
@@ -270,21 +270,29 @@ class extractWindow(QDialog):
         def evalRegex():
             regex = expressionbox.text()
             samplefile = samplefilebox.toPlainText()
-
-
-            # if regex == "" or samplefile == "":
-                # show error window for regex blank, different error for samplefile blank
-            #    print("regex field is blank or samplefile thing: "+samplefile+"")
-            #    return
-            #DataFunctions.parseAndCompareRegex(samplefile, regex)
-            #if regexdict != None:
-            #    print(regexdict)
-
-            # testdict = {"one": 1, "two": 2, "three": 3}
-            # testdict.keys()
-
-            reout = {}
-
+            if regex == "":
+                alert = QMessageBox()
+                alert.setWindowTitle("Error")
+                alert.setText("Please enter a regular expression to evaluate")
+                alert.setIcon(QMessageBox.Critical)
+                alert.show()
+                alert.exec()
+                return
+            if samplefile == "":
+                alert = QMessageBox()
+                alert.setWindowTitle("Error")
+                alert.setText("No sample file was found. Please check the selected image directory.")
+                alert.setIcon(QMessageBox.Critical)
+                alert.show()
+                alert.exec()
+                return
+            # replace '?<' patterns with '?P<' to make compatible with re.fullmatch function
+            # first checks if '?<' corresponds to a '?<=' or '?<!' pattern first before replacing
+            # part of Python specific regular expression syntax
+            regex = DataFunctions.regexPatternCompatibility(regex)
+            # parse the sample file with the regular expression to find field values
+            reout = DataFunctions.parseAndCompareRegex(samplefile, regex)
+            # Create the GUI that displays the output
             winex = QDialog()
             winex.setWindowTitle("Evaluate Regular Expression")
             winlayout = QGridLayout()

--- a/Phindr3D-Python/src/GUI/external_windows.py
+++ b/Phindr3D-Python/src/GUI/external_windows.py
@@ -238,15 +238,7 @@ class extractWindow(QDialog):
             # replace '?<' patterns with '?P<' to make compatible with re.fullmatch function
             # first checks if '?<' corresponds to a '?<=' or '?<!' pattern first before replacing
             # part of Python specific regular expression syntax
-
-            regexlen = regex.__len__()
-            for i in range(regexlen):
-                if regex[i] == '<':
-                    if i > 0:
-                        if regex[i - 1] == '?':
-                            if i < regexlen - 1:
-                                if regex[i + 1] != '!' and regex[i + 1] != '=':
-                                    regex = regex[:i] + 'P' + regex[i:]
+            regex = DataFunctions.regexPatternCompatibility(regex)
             try:
                 alert = QMessageBox()
                 try:


### PR DESCRIPTION
The Evaluate Regular Expression button functionality from the MATLAB version has been reproduced. The button shows error messages if the sample file or regular expression boxes are blank. If both have values, the regex is checked for Python compatibility, to substitute "?P<" where necessary.
The sample file is compared with the Python compatible regex, and fields are found and passed back in a dictionary. The dictionary values are shown in a window to provide feedback to the user. The format of the output window is the same as the MATLAB version.