### PR TITLE
Tileinfobug

### DIFF
--- a/Phindr3D-Python/src/GUI/windows/resultsWindow.py
+++ b/Phindr3D-Python/src/GUI/windows/resultsWindow.py
@@ -9,6 +9,8 @@ import pandas as pd
 from .plot_functions import *
 from ...Training import *
 
+Generator = Generator()
+
 class resultsWindow(QDialog):
     def __init__(self, color):
         super(resultsWindow, self).__init__()
@@ -18,7 +20,7 @@ class resultsWindow(QDialog):
         self.plots=[]
         self.filtered_data=0
         self.numcluster=None
-        self.metadata=Metadata()
+        self.metadata=Metadata(Generator)
         self.bounds=0
         self.color=color
         #menu tabs

--- a/Phindr3D-Python/src/GUI/windows/segmentationWindow.py
+++ b/Phindr3D-Python/src/GUI/windows/segmentationWindow.py
@@ -21,12 +21,14 @@ from Data import *
 from Segmentation import *
 from .helperclasses import *
 
+Generator = Generator()
+
 class segmentationWindow(QDialog):
     def __init__(self):
         super(segmentationWindow, self).__init__()
         self.setWindowTitle("Organoid Segmentation")
         self.setLayout(QGridLayout())
-        self.metadata = Metadata()
+        self.metadata = Metadata(Generator)
         self.outdir = None
         self.segmentation = Segmentation()
         self.labelIM = None #numpy array or None

--- a/Phindr3D-Python/src/Segmentation/Segmentation.py
+++ b/Phindr3D-Python/src/Segmentation/Segmentation.py
@@ -116,7 +116,7 @@ class Segmentation:
 
                 zVals = list(imstack.stackLayers.keys())
                 channels = list(imstack.stackLayers[zVals[0]].channels.keys())
-                otherparams = imstack.stackLayers[zVals[0]].otherparams
+                otherparams = imstack.GetOtherParams()
                 filenameParts = []
                 for param in otherparams:
                     part = f'{param[0]}{otherparams[param]}'
@@ -175,9 +175,9 @@ class Segmentation:
 
 if __name__ == '__main__':
     """Tests of the Segmentation class that can be run directly."""
-    from Data import Metadata
-    
-    mdata = Metadata()
+    from Data import Metadata, Generator
+    deterministic = Generator(1234)
+    mdata = Metadata(deterministic)
     segtest = Segmentation()
 
     segtest.outputDir = 'testdata\\segmentation_tests\\check_results'

--- a/Phindr3D-Python/src/VoxelGroups/MegaVoxelImage.py
+++ b/Phindr3D-Python/src/VoxelGroups/MegaVoxelImage.py
@@ -33,10 +33,11 @@ class MegaVoxelImage(VoxelBase):
         megaVoxelsforTraining = []
         for id in metadata.trainingSet:
             d = metadata.getImageInformation(metadata.GetImage(id))
+            info = metadata.getTileInfo(d, metadata.theTileInfo)
             pixelCenters = pixelImage.pixelBinCenters
             pixelBinCenterDifferences = np.array([DataFunctions.mat_dot(pixelCenters, pixelCenters, axis=1)]).T
-            superVoxelProfile, fgSuperVoxel = self.getTileProfiles(metadata, metadata.GetImage(id), pixelCenters, pixelBinCenterDifferences, metadata.theTileInfo)
-            megaVoxelProfile, fgMegaVoxel, dump = self.getMegaVoxelProfile(superVoxel.superVoxelBinCenters, superVoxelProfile, metadata.theTileInfo, fgSuperVoxel, training, analysis=False)
+            superVoxelProfile, fgSuperVoxel = self.getTileProfiles(metadata, metadata.GetImage(id), pixelCenters, pixelBinCenterDifferences, info)
+            megaVoxelProfile, fgMegaVoxel, dump = self.getMegaVoxelProfile(superVoxel.superVoxelBinCenters, superVoxelProfile, info, fgSuperVoxel, training, analysis=False)
             if len(megaVoxelsforTraining) == 0:
                 megaVoxelsforTraining = megaVoxelProfile[fgMegaVoxel]
             else:

--- a/Phindr3D-Python/src/VoxelGroups/SuperVoxelImage.py
+++ b/Phindr3D-Python/src/VoxelGroups/SuperVoxelImage.py
@@ -35,7 +35,7 @@ class SuperVoxelImage(VoxelBase):
         for id in metadata.trainingSet:
             currentIm = metadata.GetImage(id)
             d = metadata.getImageInformation(currentIm)
-            info = metadata.getTileInfo(d, metadata.theTileInfo) #good till here.
+            info = metadata.getTileInfo(d, metadata.theTileInfo)
             superVoxelProfile, fgSuperVoxel = self.getTileProfiles(metadata, metadata.GetImage(id), pixelCenters, pixelBinCenterDifferences, info)
             tmp = superVoxelProfile[fgSuperVoxel]
             if tmp.size != 0:

--- a/Phindr3D-Python/src/VoxelGroups/VoxelBase.py
+++ b/Phindr3D-Python/src/VoxelGroups/VoxelBase.py
@@ -131,7 +131,10 @@ class VoxelBase:
                         croppedIM[:, :, jChan] = dfunc.rescaleIntensity(IM,
                             low=lowerbound[jChan],
                             high=upperbound[jChan])
-                except (ValueError, IndexError):
+                # except (ValueError, IndexError): #############################
+                except Exception as e:
+                    print('try rescale')
+                    print(e)
                     return errorVal
             xEnd = -theTileInfo.xOffsetEnd
             if xEnd == -0:

--- a/Phindr3D-Python/src/VoxelGroups/VoxelBase.py
+++ b/Phindr3D-Python/src/VoxelGroups/VoxelBase.py
@@ -131,10 +131,7 @@ class VoxelBase:
                         croppedIM[:, :, jChan] = dfunc.rescaleIntensity(IM,
                             low=lowerbound[jChan],
                             high=upperbound[jChan])
-                # except (ValueError, IndexError): #############################
-                except Exception as e:
-                    print('try rescale')
-                    print(e)
+                except (ValueError, IndexError):
                     return errorVal
             xEnd = -theTileInfo.xOffsetEnd
             if xEnd == -0:


### PR DESCRIPTION
tileinfo was not computed every image in getMegavoxelBincenters which was crashing phindr3D when images with non-consistent shape were passed.

fixed it and updated other places that metadata had not been changed for easier unit testing