### PR TITLE
Fix zero division error, return type handling from Image.GetTreatment, default column in Image and Stack

### DIFF
--- a/Phindr3D-Python/src/Data/Image.py
+++ b/Phindr3D-Python/src/Data/Image.py
@@ -43,16 +43,20 @@ class Image:
             self.stackLayers[key] = newStackLayer
     # end addStackLayers
 
-    def GetTreatment(self):
+    def GetTreatment(self, treatmentColumnName='Treatment'):
         """Treatment is an optional column in the metadata. Treatment values are stored
             on separate lines, though one image should have a unique treatment value.
             This method gets the Treatment values from the member stackLayers, if they exist.
-            If they are all None, this method returns None. This method returns a list
-            of the different values found."""
+            If they are all None, or if more than one value is found, this method returns None.
+            treatmentColumnName has a default value of 'Treatment'. If the value of
+            treatmentColumnName is 'ImageID', this method returns this Image ID."""
+        if treatmentColumnName == 'ImageID':
+            return self.imageID
+        # else
         tmpList = []
         try:
             for stkID in self.stackLayers:
-                tmpList.append(self.stackLayers[stkID].GetTreatment())
+                tmpList.append(self.stackLayers[stkID].GetTreatment(treatmentColumnName))
         except AttributeError:
             return None
         # Use set to find unique values in a list, then change type back to list

--- a/Phindr3D-Python/src/Data/Metadata.py
+++ b/Phindr3D-Python/src/Data/Metadata.py
@@ -254,7 +254,7 @@ class Metadata:
                     if isinstance(tmpTreat, list):
                         treatmentList.extend(tmpTreat)
                     else:
-                        pass
+                        treatmentList.append(tmpTreat)
                 # Use set to find unique values in a list, then change type back to list
                 treatmentList = list(set(treatmentList))
                 treatmentList.sort()
@@ -325,8 +325,11 @@ class Metadata:
             allTreatments = self.GetAllTreatments()
             allTrKeys = np.array(list(allTreatments.keys()))
             allTrValues = np.array(list(allTreatments.values()))
-            randTrainingPerTreatment = \
-                -(-randTrainingFields//len(uTreat)) #ceiling division
+            try:
+                randTrainingPerTreatment = \
+                    -(-randTrainingFields//len(uTreat)) #ceiling division
+            except ZeroDivisionError:
+                randTrainingPerTreatment = 1
             randFieldIDList = []
             for treat in uTreat:
                 tempList = []
@@ -400,7 +403,7 @@ class Metadata:
                 # index of the treatment for this image in the list of all treatments
                 # if the treatment type is not found (or there are no treatments), return error
                 try:
-                    grpVal[i] = allTreatmentTypes.index(theImageObject.GetTreatment()[0])
+                    grpVal[i] = allTreatmentTypes.index(theImageObject.GetTreatment())
                 except (ValueError, IndexError):
                     return errorVal
         # end for images
@@ -570,7 +573,7 @@ class Metadata:
             # index of the treatment for this image in the list of all treatments
             # if the treatment type is not found (or there are no treatments), return error
             try:
-                grpVal = allTreatmentTypes.index(imageObject.GetTreatment()[0])
+                grpVal = allTreatmentTypes.index(imageObject.GetTreatment())
             except (ValueError, IndexError):
                 return errorVal
         # end if
@@ -690,6 +693,8 @@ if __name__ == '__main__':
         print(f'Intensity threshold expected result: {intequal}')
         print("===")
         test.intensityNormPerTreatment = True
+        test.treatmentColNameForNormalization = 'Treatment'
+        test.trainingColforImageCategories = 'Treatment'
         print("Running computeImageParameters by treatment: " + "Successful" if test.computeImageParameters() else "Unsuccessful")
         print("===")
         treatlowerequal = (test.lowerbound == np.array(expected['treatment_lowerbound'])).all()

--- a/Phindr3D-Python/src/Data/Metadata.py
+++ b/Phindr3D-Python/src/Data/Metadata.py
@@ -224,7 +224,7 @@ class Metadata:
                     elif isinstance(tmpTreat, list):
                         treat = tmpTreat[0]
                     else:
-                        treat = None
+                        treat = tmpTreat
                     allTreatments[imgID] = treat
             else:
                 pass
@@ -325,6 +325,7 @@ class Metadata:
             allTreatments = self.GetAllTreatments()
             allTrKeys = np.array(list(allTreatments.keys()))
             allTrValues = np.array(list(allTreatments.values()))
+            # Protect against ZeroDivisionError if len(uTreat) is 0
             try:
                 randTrainingPerTreatment = \
                     -(-randTrainingFields//len(uTreat)) #ceiling division
@@ -663,45 +664,51 @@ class Metadata:
 if __name__ == '__main__':
     import json
     """Tests of the Metadata class that can be run directly."""
-    # For testing purposes:
-    # Running will prompt user for a text file, image id, stack id, and channel number
-    # Since this is only for testing purposes, assume inputted values are all correct types
 
     deterministic = Generator(1234)
 
     metadatafile = 'testdata/metadata_tests/metadatatest_metadata.txt'
 
     test = Metadata(deterministic)
-    if test.loadMetadataFile(metadatafile):
+    try:
+        if test.loadMetadataFile(metadatafile):
 
-        with open('testdata/metadata_tests/expected.json', 'r') as js:
-            expected = json.load(js)
-            js.close()
+            with open('testdata/metadata_tests/expected.json', 'r') as js:
+                expected = json.load(js)
+                js.close()
 
-        print("So, did it load? " + "Yes!" if test.metadataLoadSuccess else "No.")
-        print("===")
-        print("Running computeImageParameters: " + "Successful" if test.computeImageParameters() else "Unsuccessful")
-        print("===")
-        print('Calculated image parameter comparisons...')
-        print("Lower bound compare: " + str(test.lowerbound) + " and " + str(np.array(expected['lowerbound'])))
-        print("Upper bound compare: " + str(test.upperbound) + " and " + str(np.array(expected['upperbound'])))
-        print("intensityThreshold compare: " + str(test.intensityThreshold) + " and " + str(np.array(expected['intensity_threshold'])))
-        lowerequal = (test.lowerbound == np.array(expected['lowerbound'])).all()
-        upperequal = (test.upperbound == np.array(expected['upperbound'])).all()
-        intequal = (test.intensityThreshold == np.array(expected['intensity_threshold'])).all()
-        print(f'Scaling factor expected result: { lowerequal and upperequal }')
-        print(f'Intensity threshold expected result: {intequal}')
-        print("===")
-        test.intensityNormPerTreatment = True
-        test.treatmentColNameForNormalization = 'Treatment'
-        test.trainingColforImageCategories = 'Treatment'
-        print("Running computeImageParameters by treatment: " + "Successful" if test.computeImageParameters() else "Unsuccessful")
-        print("===")
-        treatlowerequal = (test.lowerbound == np.array(expected['treatment_lowerbound'])).all()
-        treatupperequal = (test.upperbound == np.array(expected['treatment_upperbound'])).all()
-        treatintequal = (test.intensityThreshold == np.array(expected['treatment_intensity_threshold'])).all()
-        print(f'Scaling factors by treatment expected result: {treatlowerequal and treatupperequal}')
-        print(f'Intensity threshold expected result: {treatintequal}')
-    else:
-        print("loadMetadataFile was unsuccessful")
+            print("So, did it load? " + "Yes!" if test.metadataLoadSuccess else "No.")
+            print("===")
+            print("Running computeImageParameters: " + "Successful" if test.computeImageParameters() else "Unsuccessful")
+            print("===")
+            print('Calculated image parameter comparisons...')
+            print("Lower bound compare: " + str(test.lowerbound) + " and " + str(np.array(expected['lowerbound'])))
+            print("Upper bound compare: " + str(test.upperbound) + " and " + str(np.array(expected['upperbound'])))
+            print("intensityThreshold compare: " + str(test.intensityThreshold) + " and " + str(np.array(expected['intensity_threshold'])))
+            lowerequal = (test.lowerbound == np.array(expected['lowerbound'])).all()
+            upperequal = (test.upperbound == np.array(expected['upperbound'])).all()
+            intequal = (test.intensityThreshold == np.array(expected['intensity_threshold'])).all()
+            print(f'Scaling factor expected result: { lowerequal and upperequal }')
+            print(f'Intensity threshold expected result: {intequal}')
+            print("===")
+            test.intensityNormPerTreatment = True
+            test.treatmentColNameForNormalization = 'Treatment'
+            test.trainingColforImageCategories = 'Treatment'
+            # Run the test with the new Treatment settings
+            treatmentTestRun = test.computeImageParameters()
+            print("Running computeImageParameters by treatment: " + "Successful" if treatmentTestRun else "Unsuccessful")
+            print("===")
+            print("Lower bound compare: " + str(test.lowerbound) + " and " + str(np.array(expected['treatment_lowerbound'])))
+            print("Upper bound compare: " + str(test.upperbound) + " and " + str(np.array(expected['treatment_upperbound'])))
+            print("intensityThreshold compare: " + str(test.intensityThreshold) + " and " + str(
+                np.array(expected['treatment_intensity_threshold'])))
+            treatlowerequal = (test.lowerbound == np.array(expected['treatment_lowerbound'])).all()
+            treatupperequal = (test.upperbound == np.array(expected['treatment_upperbound'])).all()
+            treatintequal = (test.intensityThreshold == np.array(expected['treatment_intensity_threshold'])).all()
+            print(f'Scaling factors by treatment expected result: {treatlowerequal and treatupperequal}')
+            print(f'Intensity threshold expected result: {treatintequal}')
+        else:
+            print("loadMetadataFile was unsuccessful")
+    except FileNotFoundError:
+        print("File not found in loadMetadataFile")
 # end main

--- a/Phindr3D-Python/src/Data/Stack.py
+++ b/Phindr3D-Python/src/Data/Stack.py
@@ -46,12 +46,12 @@ class Stack:
             rowi += 1
     # end addChannels
 
-    def GetTreatment(self):
+    def GetTreatment(self, treatmentColumnName='Treatment'):
         """Treatment is an optional column in the metadata. If the column exists,
             this method returns the value from that column. If no Treatment value was
             found in the metadata, this method returns None."""
         try:
-            return self.otherparams['Treatment']
+            return self.otherparams[treatmentColumnName]
         except KeyError:
             return None
     # end GetTreatment

--- a/Phindr3D-Python/src/VoxelGroups/PixelImage.py
+++ b/Phindr3D-Python/src/VoxelGroups/PixelImage.py
@@ -54,7 +54,7 @@ class PixelImage(VoxelBase):
         trPixels = np.zeros((training.pixelsPerImage * randZ, metadata.GetNumChannels()))
         startVal = 0
         if metadata.intensityNormPerTreatment:
-            grpVal = np.argwhere(metadata.GetTreatmentTypes() == image.GetTreatment()[0])
+            grpVal = np.argwhere(metadata.GetTreatmentTypes() == image.GetTreatment())
         slices = slices[0:(len(slices) // 2)]
         for zplane in slices:
             croppedIM = np.zeros((tileinfo.origX, tileinfo.origY, metadata.GetNumChannels()))

--- a/Phindr3D-Python/src/VoxelGroups/VoxelBase.py
+++ b/Phindr3D-Python/src/VoxelGroups/VoxelBase.py
@@ -102,7 +102,7 @@ class VoxelBase:
             # index of the treatment for this image in the list of all treatments
             # if the treatment type is not found (or there are no treatments), return error
             try:
-                grpVal = allTreatmentTypes.index(imageObject.GetTreatment()[0])
+                grpVal = allTreatmentTypes.index(imageObject.GetTreatment())
             except (ValueError, IndexError):
                 return errorVal
         # end if


### PR DESCRIPTION
This version corrects the errors we've been seeing, but does not yet handle Treatment column names besides 'Treatment'. That is still in another branch, and I am contributing the changes in stages. Next stage is to change the expected values for the metadata_tests.