### PR TITLE
Fix sampling with asymmetric numbers of images in treatment, e.g. by Object

### DIFF
--- a/Phindr3D-Python/src/Data/Image.py
+++ b/Phindr3D-Python/src/Data/Image.py
@@ -37,7 +37,6 @@ class Image:
         # layerlist is a list of rows of metadata, each represented as a list of data elements
         for layer in layerlist:
             key = layer[layer.__len__() - 3] # index len - 3 will always be stack column
-            self.setImageID(key)
             newStackLayer = Stack()
             newStackLayer.addChannels(layer, columnlabels)
             self.stackLayers[key] = newStackLayer
@@ -51,7 +50,7 @@ class Image:
             treatmentColumnName has a default value of 'Treatment'. If the value of
             treatmentColumnName is 'ImageID', this method returns this Image ID."""
         if treatmentColumnName == 'ImageID':
-            return self.imageID
+            return str(self.imageID)
         # else
         tmpList = []
         try:

--- a/Phindr3D-Python/src/Data/Image.py
+++ b/Phindr3D-Python/src/Data/Image.py
@@ -44,13 +44,13 @@ class Image:
 
     def GetTreatment(self, treatmentColumnName='Treatment'):
         """Treatment is an optional column in the metadata. Treatment values are stored
-            on separate lines, though one image should have a unique treatment value.
+            on separate lines, though one ImageID should have a unique treatment value.
             This method gets the Treatment values from the member stackLayers, if they exist.
             If they are all None, or if more than one value is found, this method returns None.
             treatmentColumnName has a default value of 'Treatment'. If the value of
             treatmentColumnName is 'ImageID', this method returns this Image ID."""
         if treatmentColumnName == 'ImageID':
-            return str(self.imageID)
+            return (self.imageID)
         # else
         tmpList = []
         try:

--- a/Phindr3D-Python/src/Data/Metadata.py
+++ b/Phindr3D-Python/src/Data/Metadata.py
@@ -232,7 +232,6 @@ class Metadata:
             dictionary: { key=imageID : value=treatment, ... }
             """
         treatmentColumnName = self.GetTreatmentColumnName()
-
         allTreatments = {}
         try:
             if len(self.images) > 0:
@@ -731,7 +730,7 @@ if __name__ == '__main__':
             print(f'Intensity threshold expected result: {intequal}')
             print("===")
             test.intensityNormPerTreatment = True
-            test.treatmentColNameForNormalization = 'NotTreatment'
+            test.treatmentColNameForNormalization = 'Treatment'
             test.trainingColforImageCategories = 'Treatment'
             # Run the test with the new Treatment settings
             treatmentTestRun = test.computeImageParameters()

--- a/Phindr3D-Python/src/Data/Metadata.py
+++ b/Phindr3D-Python/src/Data/Metadata.py
@@ -458,15 +458,6 @@ class Metadata:
         return (lowerbound, upperbound)
     # end getScalingFactorforImages
 
-
-
-
-
-
-
-
-
-
     def getImageInformation(self, theImage, chan=0):
         """Get information about the image files.
             Called in getPixelBinCenters, getImageThresholdValues,

--- a/Phindr3D-Python/src/Data/Metadata.py
+++ b/Phindr3D-Python/src/Data/Metadata.py
@@ -329,15 +329,12 @@ class Metadata:
         On error, returns an empty numpy array
         """
         randFieldID = np.array([])
-
         # Check the type of numTrainingFields
         if not isinstance(numTrainingFields, int):
             return randFieldID
-
         # Get the list of all image IDs in the set
         uniqueImageID = np.array(self.GetAllImageIDs())
         numImageIDs = len(uniqueImageID)
-
         # randTrainingFields is numTrainingFields, unless numTrainingFields is larger than numImageIDs
         randTrainingFields = numImageIDs if numImageIDs < numTrainingFields else numTrainingFields
 
@@ -363,11 +360,13 @@ class Metadata:
                 tempList = []
                 try:
                     treatmentIDs = allTrKeys[allTrValues == treat]
-                    if len(treatmentIDs) > 0:
+                    if len(treatmentIDs) > randTrainingPerTreatment:
                         tempList = [treatmentIDs[j] for j in
                             self.Generator.Generator.choice(len(treatmentIDs), size=randTrainingPerTreatment,
                                 replace=False, shuffle=False)]
-                except (ValueError,KeyError):
+                    elif len(treatmentIDs) > 0 and len(treatmentIDs) <= randTrainingPerTreatment:
+                        tempList = list(treatmentIDs)
+                except (ValueError,KeyError) as e:
                     tempList = []
                 randFieldIDList = randFieldIDList + tempList
             randFieldIDList.sort()
@@ -391,7 +390,6 @@ class Metadata:
         numImages = randFieldIDforNormalization.size
         # Get the list of all treatment types
         allTreatmentTypes = self.GetTreatmentTypes()
-
         if self.intensityNormPerTreatment:
             grpVal = np.zeros(numImages)
         # blank array for min values of all selected images in all channels
@@ -459,6 +457,15 @@ class Metadata:
             upperbound = mquantiles(maxChannel, 0.99, alphap=0.5, betap=0.5, axis=0).ravel()
         return (lowerbound, upperbound)
     # end getScalingFactorforImages
+
+
+
+
+
+
+
+
+
 
     def getImageInformation(self, theImage, chan=0):
         """Get information about the image files.
@@ -704,6 +711,7 @@ if __name__ == '__main__':
     """Tests of the Metadata class that can be run directly."""
 
     deterministic = Generator(1234)
+    rng = Generator()
 
     metadatafile = 'testdata/metadata_tests/metadatatest_metadata.txt'
 

--- a/Phindr3D-Python/src/VoxelGroups/VoxelGroups.py
+++ b/Phindr3D-Python/src/VoxelGroups/VoxelGroups.py
@@ -188,7 +188,7 @@ if __name__ == '__main__':
     import pandas as pd
     import os
     deterministic = Generator(1234)
-    metadatafile = r'testdata\metadata_tests\metadatatest_metadata.txt'
+    metadatafile = 'testdata/metadata_tests/metadatatest_metadata.txt'
     test = Metadata(deterministic)
     if test.loadMetadataFile(metadatafile):
         print("So, did the metadata load? " + "Yes!" if test.metadataLoadSuccess else "No.")


### PR DESCRIPTION
Testing with organoid segmented images led to discovering that when using Object as the treatment column, not all object numbers were being included. The reason is that object numbers are repeated between images, but since the images can have different numbers of objects, there can be different numbers of constituent images.
The numpy Generator was unable to deal with a smaller number of samples than were requested. So, for:
Image 1: 3 objects
Image 2: 4 objects
When 2 samples per Object were requested, the last object number, 4, produced the error: "Cannot take a larger sample than population when replace is False".
There is now an if statement to include all samples if the actual number is smaller than the requested number.